### PR TITLE
Fix camp/participant dropdown overflow

### DIFF
--- a/resources/css/libs/custom.css
+++ b/resources/css/libs/custom.css
@@ -316,10 +316,6 @@ select option {
     background-color: var(--color-bg-primary);
 }
 
-.h-dropdown{
-    max-height: 85vh;
-}
-
 .swal2-actions button{
     background-color: var(--swal2-confirm-button-background-color);
 }

--- a/resources/views/components/layouts/camp-dropdown.blade.php
+++ b/resources/views/components/layouts/camp-dropdown.blade.php
@@ -14,7 +14,7 @@
     <div
         class="hidden z-50 my-4 w-56 text-base list-none navbar-background divide-y divide-gray-100 shadow-xs dark:bg-gray-700 dark:divide-gray-600 rounded-xl"
         id="dropdown-curses">
-        <ul aria-labelledby="dropdown-curses" class="h-dropdown py-1 text-gray-700 dark:text-gray-300 overflow-y-auto" >
+        <ul aria-labelledby="dropdown-curses" class="max-h-[85vh] py-1 text-gray-700 dark:text-gray-300 overflow-y-auto" >
             @if(!Auth::user()->demo )
                 <li>
                     <a class="block py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"

--- a/resources/views/includes/topnav.blade.php
+++ b/resources/views/includes/topnav.blade.php
@@ -53,7 +53,7 @@
                                     </button>
                                 </li>
                                 <div
-                                    class="hidden z-50 my-4 w-56 text-base list-none navbar-background divide-y divide-gray-100 shadow-xs dark:bg-gray-700 dark:divide-gray-600 rounded-xl"
+                                    class="hidden z-50 my-4 w-56 text-base list-none navbar-background divide-y divide-gray-100 shadow-xs dark:bg-gray-700 dark:divide-gray-600 rounded-xl max-h-[85vh] overflow-y-auto"
                                     id="dropdown-users"
                                 >
                                 
@@ -72,7 +72,7 @@
                                         <hr class="h-px bg-gray-400 border-0 dark:bg-gray-200">
                                     @endif
                                     @if(count($camp->other_participants)>0)
-                                    <ul aria-labelledby="dropdown-users" class="h-dropdown py-1 text-gray-700 dark:text-gray-300 overflow-y-auto">
+                                    <ul aria-labelledby="dropdown-users" class="py-1 text-gray-700 dark:text-gray-300">
                                         @foreach ($camp->other_participants as $user_profile)
                                             <li>
                                                 <a class="block py-2 px-4 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-400 dark:hover:text-white"


### PR DESCRIPTION
The dropdown currently overflows since a leaders own participants are not taken into account when doing the overflow calculation. This was fixed by adding the overflow handling in the parent div.