### PR TITLE
fix: resolve feedback document upload, avatar corruption, and demo mode file input

### DIFF
--- a/app/Http/Controllers/AdminUsersController.php
+++ b/app/Http/Controllers/AdminUsersController.php
@@ -343,9 +343,9 @@ class AdminUsersController extends Controller
         if (!Auth::user()->demo) {
             $camp = $aktUser->camp;
             if (trim($request->password) == '') {
-                $input = $request->except('password');
+                $input = $request->except(['password', 'avatar']);
             } else {
-                $input = $request->all();
+                $input = $request->except('avatar');
                 $input['password'] = bcrypt($request->password);
             }
 
@@ -432,9 +432,9 @@ class AdminUsersController extends Controller
 
         if (! $aktuser->demo) {
             if (trim($request->password) == '') {
-                $input = $request->except('password');
+                $input = $request->except(['password', 'avatar']);
             } else {
-                $input = $request->all();
+                $input = $request->except('avatar');
                 $input['password'] = bcrypt($request->password);
             }
             // $input['slug'] = Str::slug($input['username']);

--- a/app/View/Components/Forms/Form.php
+++ b/app/View/Components/Forms/Form.php
@@ -24,14 +24,21 @@ class Form extends Component
      * Request method.
      */
     public $model;
+
+    /**
+     * Form enctype.
+     */
+    public ?string $enctype;
+
     /**
      * Create a new component instance.
      */
-    public function __construct(string $method = 'POST', $model = [])
+    public function __construct(string $method = 'POST', $model = [], string $enctype = null)
     {
         $this->method = strtoupper($method);
         $this->model = $model;
         $this->spoofMethod = in_array($this->method, ['PUT', 'PATCH', 'DELETE']);
+        $this->enctype = $enctype;
     }
 
     public function hasError($bag = 'default'): bool

--- a/app/View/Components/Forms/Form.php
+++ b/app/View/Components/Forms/Form.php
@@ -33,7 +33,7 @@ class Form extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct(string $method = 'POST', $model = [], string $enctype = null)
+    public function __construct(string $method = 'POST', $model = [], ?string $enctype = null)
     {
         $this->method = strtoupper($method);
         $this->model = $model;

--- a/resources/views/components/forms/file.blade.php
+++ b/resources/views/components/forms/file.blade.php
@@ -1,4 +1,4 @@
 @aware(['model'])
 
 @if($label != '')<label class="block mb-2 text-sm font-medium text-gray-900 dark:text-white" for="{{ $name }}">{{ $label }} </label>@endif
-<input type="file" id="{{ $id }}" name="{{ $name }}" class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400" {{ $required ? 'required' : ''}} {{$attributes}}>
+<input type="file" id="{{ $id }}" name="{{ $name }}" class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 disabled:opacity-25 disabled:cursor-not-allowed" {{ $required ? 'required' : ''}} {{$attributes}}>

--- a/resources/views/components/forms/form.blade.php
+++ b/resources/views/components/forms/form.blade.php
@@ -1,4 +1,4 @@
-<form method="{{ $spoofMethod ? 'POST' : $method }}" {!! $attributes !!}>
+<form method="{{ $spoofMethod ? 'POST' : $method }}" {!! $attributes !!} @if($enctype) enctype="{{ $enctype }}" @endif>
     @unless(in_array($method, ['HEAD', 'GET', 'OPTIONS']))
         @csrf
     @endunless

--- a/resources/views/components/posts/form.blade.php
+++ b/resources/views/components/posts/form.blade.php
@@ -15,7 +15,10 @@
         <p class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">oder</p>
     </div>
     <x-forms.container>
-        <x-forms.file name="file"/>
+        <x-forms.file name="file" :disabled="Auth::user()->demo"/>
+        @if(Auth::user()->demo)
+            <p class="mt-1 text-xs text-red-500">Dateiupload in der Demoversion deaktiviert</p>
+        @endif
     </x-forms.container>
     <x-forms.container>
        <x-forms.checkbox label="Sichtbar für Qualifikation" name="show_on_survey" value="{{$post['show_on_survey']}}"/>


### PR DESCRIPTION
This pull request fixes several bugs related to the document upload system and the demo mode user configuration:

1. **Document Upload Support**: Fixes document upload failure when attaching files to feedback posts by explicitly adding and rendering the `enctype` attribute inside `Form.php` and `form.blade.php`.
2. **User Avatar Corruption Fix**: Excludes the `avatar` UploadedFile object from user update mass assignments inside `AdminUsersController.php` to prevent temp paths (e.g. `tmp/phpXXXX`) from corrupting profiles.
3. **Demo Mode Enhancements**:
   - Disables the file input and renders a helpful red warning inside the feedback form if the logged-in user is a demo user (`demo = true`).
   - Styled the disabled file input using `disabled:opacity-25` and `disabled:cursor-not-allowed` to properly gray it out.